### PR TITLE
fix: use pre-configured env when calling run

### DIFF
--- a/meltano/edk/process.py
+++ b/meltano/edk/process.py
@@ -68,6 +68,13 @@ class Invoker:
         stdout and stderr by default are set up to use subprocess.PIPE. If you do not
         want to capture io from the subprocess use subprocess.DEVNULL to discard it.
 
+        The Invoker's at env and cwd are used when calling subprocess.run. If you want
+        to override these you're likely better served using subprocess.run directly.
+
+        Lastly note that this method is blocking AND subprocess.run is called with
+        check=True. This means that if the subprocess fails a CalledProcessError will
+        be raised.
+
         Args:
             *args: The arguments to pass to the subprocess.
             stdout: The stdout stream to use.
@@ -75,14 +82,13 @@ class Invoker:
             text: If true, decode stdin, stdout and stderr using the system default.
             **kwargs: Additional keyword arguments to pass to subprocess.run.
 
-        May indirectly raise CalledProcessError if the underlying subprocess failed.
-
         Returns:
             The completed process.
         """
         return subprocess.run(
             [self.bin, *args],
             cwd=self.cwd,
+            env=self.popen_env,
             stdout=stdout,
             stderr=stderr,
             check=True,

--- a/meltano/edk/process.py
+++ b/meltano/edk/process.py
@@ -68,11 +68,11 @@ class Invoker:
         stdout and stderr by default are set up to use subprocess.PIPE. If you do not
         want to capture io from the subprocess use subprocess.DEVNULL to discard it.
 
-        The Invoker's at env and cwd are used when calling subprocess.run. If you want
-        to override these you're likely better served using subprocess.run directly.
+        The Invoker's at env and cwd are used when calling `subprocess.run`. If you want
+        to override these you're likely better served using `subprocess.run` directly.
 
-        Lastly note that this method is blocking AND subprocess.run is called with
-        check=True. This means that if the subprocess fails a CalledProcessError will
+        Lastly note that this method is blocking AND `subprocess.run` is called with
+        `check=True`. This means that if the subprocess fails a `CalledProcessError` will
         be raised.
 
         Args:


### PR DESCRIPTION
closes #14 