### PR TITLE
fix: gather stdio proxy tasks

### DIFF
--- a/meltano/edk/process.py
+++ b/meltano/edk/process.py
@@ -128,8 +128,16 @@ class Invoker:
             stderr=asyncio.subprocess.PIPE,
             env=self.popen_env,
         )
-        asyncio.create_task(self._log_stdio(p.stderr))
-        asyncio.create_task(self._log_stdio(p.stdout))
+
+        results = await asyncio.gather(
+            asyncio.create_task(self._log_stdio(p.stderr)),
+            asyncio.create_task(self._log_stdio(p.stdout)),
+            return_exceptions=True,
+        )
+
+        for r in results:  # raise first exception if any
+            if isinstance(r, Exception):
+                raise r
 
         await p.wait()
         return p


### PR DESCRIPTION
Noticed I never actually gathered or awaited the stdio proxy/logger tasks. 