### PR TITLE
fix: have copier pull from edk repo rather than old edk-template repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pipx install copier
 Start a new EDK project using the supplied template (directly from Github):
 
 ```bash
-copier gh:meltano/edk-template my-new-extension
+copier gh:meltano/edk my-new-extension
 ```
 
 Install the project dependencies:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ extensions = [
 ]
 
 # Auto-parse markdown (using myst_parser) as well as RST
-source_suffix = ['.rst', '.md']
+source_suffix = [".rst", ".md"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -25,7 +25,7 @@ pipx install copier
 Start a new EDK project using the supplied template (directly from Github):
 
 ```bash
-copier gh:meltano/edk-template my-new-extension
+copier gh:meltano/edk my-new-extension
 ```
 
 Install the project dependencies:


### PR DESCRIPTION
https://meltano.slack.com/archives/C01UGBSJNG5/p1666788865481979

<!-- readthedocs-preview meltano-edk start -->
----
:books: Documentation preview :books:: https://meltano-edk--34.org.readthedocs.build/en/34/

<!-- readthedocs-preview meltano-edk end -->