### PR TITLE
chore: Drop redundant dependencies from copier template

### DIFF
--- a/copier_template/pyproject.toml.jinja
+++ b/copier_template/pyproject.toml.jinja
@@ -16,10 +16,8 @@ packages = [
 #]
 
 [tool.poetry.dependencies]
-python = "<3.11,>=3.7"
-structlog = "^21.2.0"
+python = "<3.12,>=3.7"
 PyYAML = "^6.0.0"
-pydantic = "^1.9.0"
 click = "^8.1.3"
 typer = "^0.6.1"
 "meltano.edk"= {git = "https://github.com/meltano/edk.git", rev="main"}


### PR DESCRIPTION


<!-- readthedocs-preview meltano-edk start -->
----
:books: Documentation preview :books:: https://meltano-edk--46.org.readthedocs.build/en/46/

<!-- readthedocs-preview meltano-edk end -->