### PR TITLE
chore: Use `PYPI_SECRET_TOKEN` instead of `PYPI_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
         file_glob: true
     - name: Deploy to PyPI
       run: |
-        poetry publish -u "__token__" -p "${{ secrets.PYPI_TOKEN }}"
+        poetry publish -u "__token__" -p "${{ secrets.PYPI_SECRET_TOKEN }}"


### PR DESCRIPTION


<!-- readthedocs-preview meltano-edk start -->
----
:books: Documentation preview :books:: https://meltano-edk--62.org.readthedocs.build/en/62/

<!-- readthedocs-preview meltano-edk end -->