### PR TITLE
chore: Use PyPI OIDC to publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   build_and_release:
 
     runs-on: ubuntu-latest
+    environment: publishing
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,11 @@ name: Build & Release
 
 on:
   release:
-    types: [created]
+    types: [published]  # Trigger only when a release is published, not when a release is drafted
+
+permissions:
+  contents: write  # Needed to upload artifacts to the release
+  id-token: write  # Needed for OIDC PyPI publishing
 
 jobs:
   build_and_release:
@@ -35,6 +39,5 @@ jobs:
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
-    - name: Deploy to PyPI
-      run: |
-        poetry publish -u "__token__" -p "${{ secrets.PYPI_SECRET_TOKEN }}"
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@v1.8.5


### PR DESCRIPTION
TODO: decide if we want to set up an _environment_ for releases.

For now, I've created a published without an environment.

<!-- readthedocs-preview meltano-edk start -->
----
:books: Documentation preview :books:: https://meltano-edk--97.org.readthedocs.build/en/97/

<!-- readthedocs-preview meltano-edk end -->