### PR TITLE
docs: Fix docs build by specifying OS in RTD config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,16 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: true
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION


<!-- readthedocs-preview meltano-edk start -->
----
:books: Documentation preview :books:: https://meltano-edk--100.org.readthedocs.build/en/100/

<!-- readthedocs-preview meltano-edk end -->