### PR TITLE
fix: If running in Windows, do not use add_signal_handler()

### DIFF
--- a/meltano/edk/process.py
+++ b/meltano/edk/process.py
@@ -138,7 +138,7 @@ class Invoker:
         loop = asyncio.get_event_loop()
         # Windows does not support add_signal_handler
         # https://docs.python.org/3/library/asyncio-platforms.html
-        if sys.platform != 'win32':
+        if sys.platform != "win32":
             loop.add_signal_handler(
                 signal.SIGINT,
                 lambda s=signal.SIGINT: p.send_signal(s),  # type: ignore[misc]

--- a/meltano/edk/process.py
+++ b/meltano/edk/process.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import signal
 import subprocess
+import sys
 import typing as t
 
 import structlog
@@ -135,10 +136,13 @@ class Invoker:
         )
 
         loop = asyncio.get_event_loop()
-        loop.add_signal_handler(
-            signal.SIGINT,
-            lambda s=signal.SIGINT: p.send_signal(s),  # type: ignore[misc]
-        )
+        # Windows does not support add_signal_handler
+        # https://docs.python.org/3/library/asyncio-platforms.html
+        if sys.platform != 'win32':
+            loop.add_signal_handler(
+                signal.SIGINT,
+                lambda s=signal.SIGINT: p.send_signal(s),  # type: ignore[misc]
+            )
 
         streams: list[asyncio.streams.StreamReader] = []
 


### PR DESCRIPTION
# What is the issue?
- Attempts to address https://github.com/meltano/edk/issues/264
- There was a change to the EDK that allows interrupt signals to be sent to subprocesses. https://github.com/meltano/edk/pull/75
- However when packages begin using this code (in particular [dbt-ext](https://github.com/meltano/dbt-ext) at v0.2.0), any development effort on Windows machine stopped working 
- https://docs.python.org/3/library/asyncio-platforms.html

![image](https://github.com/meltano/edk/assets/84326247/69d96788-b3ed-45cf-b93a-4f3d7d628372)


# What was changed?
- At first I was trying to figure out how to implement the fix for windows: `signal.raise_signal(signal.SIGINT)` via https://stackoverflow.com/questions/35772001/how-to-handle-a-signal-sigint-on-a-windows-os-machine/72637975#72637975. The trick is that we are dealing with sub-processes here. My Python knowledge is limited at this time since Windows can't use add_signal_handler - I wasn't quite sure how to best go this way to have the subprocess use it.
- Another possible option instead is to not invoke the add_signal_handler during local Windows development - which is what this PR is trying to do.

# Example

1) Attempting to run development in Windows with `loop.add_signal_handler`
![image](https://github.com/meltano/edk/assets/84326247/e4847ca5-e637-4746-82cc-5b5584d4a37d)

2) == to != for win32 check
![image](https://github.com/meltano/edk/assets/84326247/58ddcda8-ab72-433c-bcd1-e552433000f4)

3) Checking KeyboardInterrupt works
![image](https://github.com/meltano/edk/assets/84326247/6efcd302-3442-424a-a327-b72ef90c1c10)


# Other notes

We may also be able to set an event loop policy around if the platform we are running on is in Windows - before we get the event loop afterwards. However like I mentioned above my Python knowledge is limited, especially with how async/event loops are managed. I don't think it's a good idea to introduce it but I did want to mention I took a look anyways.

```
        # If running in windows, set event loop policy instead
        if sys.platform == 'win32':
            asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
            loop = asyncio.ProactorEventLoop()
            asyncio.set_event_loop(loop)
```

---

📚 Documentation preview 📚: https://meltano-edk--274.org.readthedocs.build/en/274/