### PR TITLE
chore: Remove `reviewers` field from dependabot config to rely on CODEOWNERS file instead

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owner
+*       @meltano/engineering

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       interval: weekly
       time: "12:00"
       timezone: "UTC"
-    reviewers: [meltano/engineering]
     labels: [dependencies]
     commit-message:
       prefix: "feat(deps): "
@@ -26,7 +25,6 @@ updates:
       interval: weekly
       time: "12:00"
       timezone: "UTC"
-    reviewers: [meltano/engineering]
     labels: [dependencies]
     commit-message:
       prefix: "ci: "
@@ -38,7 +36,6 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-    reviewers: [meltano/engineering]
     labels: [dependencies]
     commit-message:
       prefix: "ci: "


### PR DESCRIPTION


<!-- readthedocs-preview meltano-edk start -->
----
📚 Documentation preview 📚: https://meltano-edk--413.org.readthedocs.build/en/413/

<!-- readthedocs-preview meltano-edk end -->