### PR TITLE
feat(deps): Use `dataclasses.dataclass` instead of Pydantic models

### DIFF
--- a/meltano/edk/extension.py
+++ b/meltano/edk/extension.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+import json
 import sys
 from abc import ABCMeta, abstractmethod
 from enum import Enum
@@ -95,13 +97,10 @@ class ExtensionBase(metaclass=ABCMeta):
         if output_format == DescribeFormat.text:
             return pformat(self.describe())
         elif output_format == DescribeFormat.json:
-            return self.describe().model_dump_json(indent=2)
+            return json.dumps(dataclasses.asdict(self.describe()), indent=2)
         elif output_format == DescribeFormat.yaml:
-            # just calling describe().dict() and dumping that to yaml yields a yaml that
-            # is subtly different to the json variant in that it you have an additional
-            # level of nesting.
             return yaml.dump(
-                yaml.safe_load(self.describe().model_dump_json()),
+                dataclasses.asdict(self.describe()),
                 sort_keys=False,
                 indent=2,
             )

--- a/meltano/edk/models.py
+++ b/meltano/edk/models.py
@@ -1,40 +1,46 @@
 """Various models used to describe extensions."""
 
-from pydantic import BaseModel
+from dataclasses import dataclass, field
 
 
-class Command(BaseModel):
+@dataclass(slots=True)
+class Command:
     """Describe a generic runnable command."""
 
     name: str
     description: str
-    commands: list[str] = []
+    commands: list[str] = field(default_factory=list)
     pass_through_cli: bool = False
 
 
+@dataclass(slots=True)
 class ExtensionCommand(Command):
     """Describes an extension command."""
 
     description: str = "The extension cli"
     pass_through_cli: bool = False
-    commands: list[str] = [
-        "describe",
-        "invoke",
-        "pre_invoke",
-        "post_invoke",
-        "initialize",
-    ]
+    commands: list[str] = field(
+        default_factory=lambda: [
+            "describe",
+            "invoke",
+            "pre_invoke",
+            "post_invoke",
+            "initialize",
+        ]
+    )
 
 
+@dataclass(slots=True)
 class InvokerCommand(Command):
     """Describes an invoker style command."""
 
     description: str = "The pass through invoker cli"
     pass_through_cli: bool = True
-    commands: list[str] = [":splat"]
+    commands: list[str] = field(default_factory=lambda: [":splat"])
 
 
-class Describe(BaseModel):
+@dataclass(slots=True)
+class Describe:
     """Describes what commands and capabilities the extension provides."""
 
     commands: list[Command]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 dependencies = [
     "structlog>=21,<26",
     "PyYAML>=6,<7",
-    "pydantic>=2,<3",
     "devtools>=0.9.0,<1",
 ]
 

--- a/tests/test_meltano_edk.py
+++ b/tests/test_meltano_edk.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
+
 import structlog
+import yaml
 
 from meltano.edk import models
-from meltano.edk.extension import ExtensionBase
+from meltano.edk.extension import DescribeFormat, ExtensionBase
 from meltano.edk.types import ExecArg
 
 
@@ -38,6 +41,38 @@ def test_invoke():
     test = CustomExtension()
     test.invoke("echo", "test")
     assert test.history == [("echo", ("test",))]
+
+
+def test_describe_formatted_json():
+    test = CustomExtension()
+    output = test.describe_formatted(DescribeFormat.json)
+    parsed = json.loads(output)
+    assert parsed == {
+        "commands": [
+            {
+                "name": "test",
+                "description": "test",
+                "commands": ["describe", "invoke", "pre_invoke", "post_invoke", "initialize"],
+                "pass_through_cli": False,
+            }
+        ]
+    }
+
+
+def test_describe_formatted_yaml():
+    test = CustomExtension()
+    output = test.describe_formatted(DescribeFormat.yaml)
+    parsed = yaml.safe_load(output)
+    assert parsed == {
+        "commands": [
+            {
+                "name": "test",
+                "description": "test",
+                "commands": ["describe", "invoke", "pre_invoke", "post_invoke", "initialize"],
+                "pass_through_cli": False,
+            }
+        ]
+    }
 
 
 def test_pass_through():

--- a/tests/test_meltano_edk.py
+++ b/tests/test_meltano_edk.py
@@ -52,7 +52,13 @@ def test_describe_formatted_json():
             {
                 "name": "test",
                 "description": "test",
-                "commands": ["describe", "invoke", "pre_invoke", "post_invoke", "initialize"],
+                "commands": [
+                    "describe",
+                    "invoke",
+                    "pre_invoke",
+                    "post_invoke",
+                    "initialize",
+                ],
                 "pass_through_cli": False,
             }
         ]
@@ -68,7 +74,13 @@ def test_describe_formatted_yaml():
             {
                 "name": "test",
                 "description": "test",
-                "commands": ["describe", "invoke", "pre_invoke", "post_invoke", "initialize"],
+                "commands": [
+                    "describe",
+                    "invoke",
+                    "pre_invoke",
+                    "post_invoke",
+                    "initialize",
+                ],
                 "pass_through_cli": False,
             }
         ]

--- a/uv.lock
+++ b/uv.lock
@@ -685,7 +685,6 @@ name = "meltano-edk"
 source = { editable = "." }
 dependencies = [
     { name = "devtools" },
-    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "structlog" },
 ]
@@ -718,7 +717,6 @@ requires-dist = [
     { name = "devtools", specifier = ">=0.9.0,<1" },
     { name = "furo", marker = "extra == 'docs'" },
     { name = "myst-parser", marker = "extra == 'docs'" },
-    { name = "pydantic", specifier = ">=2,<3" },
     { name = "pyyaml", specifier = ">=6,<7" },
     { name = "sphinx", marker = "extra == 'docs'" },
     { name = "sphinx-autobuild", marker = "extra == 'docs'" },


### PR DESCRIPTION
Pydantic is only used minimally in 4 data classses, and rely only on basic serialization and comparison features.
